### PR TITLE
Version 0.0.27 - get the XSPEC version at build time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ src/xspec_models_cxc/__init__.py
 __pycache__
 
 src/xspec.cxx
+
+helpers/report_xspec_version

--- a/helpers/identify_xspec.py
+++ b/helpers/identify_xspec.py
@@ -1,0 +1,95 @@
+"""
+Identify the version of XSPEC being built against by compiling
+a small program which calls the XSPEC "get a version" routine.
+
+The assumption is that this only needs the XSUtil library, and
+that this is unversioned (i.e. we can hard-code the name).
+
+Is this
+
+- worth the effort?
+- how do we automate the compiler choice (e.g. search for clang)
+
+"""
+
+import os
+import pathlib
+import re
+import subprocess
+
+
+def get_compiler():
+    compiler = os.getenv("CXX")
+    if compiler is not None:
+        return compiler
+
+    # We could try and be clever here, but for now just fall through
+    # to g++ and assume that anyone using clang has to set CXX.  I do
+    # not build on macOS so it's not a problem for me^(TM).
+    #
+    compiler = "g++"
+    return compiler
+
+
+def compile_code(HEADAS):
+    """Compile the code."""
+
+    basename = "report_xspec_version"
+    helpers = pathlib.Path("helpers")
+
+    compiler = get_compiler()
+    args = [compiler, str(helpers / f"{basename}.cxx"),
+            "-o", str(helpers / basename),
+            f"-I{HEADAS}/include",
+            f"-L{HEADAS}/lib", "-lXSUtil"
+        ]
+
+    subprocess.run(args, check=True)
+    return helpers / basename
+
+
+def get_xspec_macros(HEADAS):
+    """Return the macro definitions which define the XSPEC version.
+
+    Parameters
+    ----------
+    HEADAS : pathlib.Path
+        The path to the HEADAS location.
+
+    Returns
+    -------
+    xspec_version, macros : str, list
+        The XSPEC version, including the patch level, and then the
+        macro definitons to pass to the compiled code.
+
+    """
+
+    code = compile_code(HEADAS)
+    command = subprocess.run([str(code)],
+                             check=True,
+                             stdout=subprocess.PIPE)
+
+    xspec_version = command.stdout.decode().strip()
+    print(f"Building against XSPEC: '{xspec_version}'")
+
+    # split the XSPEC version
+    toks = xspec_version.split(".")
+    assert len(toks) == 3, xspec_version
+    xspec_major = toks[0]
+    xspec_minor = toks[1]
+
+    match = re.match("^(\d+)(.*)$", toks[2])
+    xspec_micro = match[1]
+    xspec_patch = None if match[2] == "" else match[2]
+
+    macros = [
+        ('BUILD_XSPEC', xspec_version),
+        ('BUILD_XSPEC_MAJOR', xspec_major),
+        ('BUILD_XSPEC_MINOR', xspec_minor),
+        ('BUILD_XSPEC_MICRO', xspec_micro),
+    ]
+
+    if xspec_patch is not None:
+        macros.append(('BUILD_XSPEC_PATCH', xspec_patch))
+
+    return xspec_version, macros

--- a/helpers/report_xspec_version.cxx
+++ b/helpers/report_xspec_version.cxx
@@ -1,0 +1,14 @@
+/*
+ * Returns the version string of XSPEC. It appears to need to be
+ * linked to just XSUtil, and does not need the library to be
+ * initialized.
+ */
+
+#include <iostream>
+
+#include <XSUtil/Utils/XSutility.h>
+
+int main(int argc, char **argv) {
+  std::cout << XSutility::xs_version() << std::endl;
+  return 0;
+}

--- a/helpers/template.py
+++ b/helpers/template.py
@@ -199,8 +199,14 @@ def apply_compiled(models, template, outfile):
         }
 
 
-def apply_python(models, template, outfile):
-    """Convert the template for the Python code."""
+def apply_python(models, template, xspec_version, outfile):
+    """Convert the template for the Python code.
+
+    xspec_version : str
+        The XSPEC library we are building against, including the patch
+        level.
+
+    """
 
     def to_model(mtype):
         return {'Add': 'ModelType.Add',
@@ -273,6 +279,7 @@ def apply_python(models, template, outfile):
         out = ifh.read()
 
         out = replace_term(out, '@@PYINFO@@', ',\n'.join(mstrs))
+        out = replace_term(out, '@@XSPECVER@@', xspec_version)
 
     with outfile.open(mode='wt') as ofh:
         ofh.write(out)
@@ -281,13 +288,16 @@ def apply_python(models, template, outfile):
 # At what point does it become worth using a templating system like
 # Jinja2?
 #
-def apply(modelfile, out_dir):
+def apply(modelfile, xspec_version, out_dir):
     """Parse the model.dat file and create the code.
 
     Parameters
     ----------
     modelfile : pathlib.Path
         The he model.dat file.
+    xspec_version : str
+        The XSPEC library we are building against, including the patch
+        level.
     out_dir : pathlib.Path
         The directory where to write the output.
 
@@ -347,7 +357,7 @@ def apply(modelfile, out_dir):
     out_dir = out_dir / 'xspec_models_cxc'
     outfile = out_dir / filename
     out_dir.mkdir(exist_ok=True)
-    apply_python(models, template, outfile)
+    apply_python(models, template, xspec_version, outfile)
 
     # It looks like info['models'] does not contain repeated values.
     #

--- a/template/__init__.py
+++ b/template/__init__.py
@@ -24,7 +24,7 @@ What version of XSPEC is being used?
 
 >>> import xspec_models_cxc as x
 >>> x.get_version()
-'12.12.0'
+'@@XSPECVER@@'
 
 What models are supported (the actual list depends on the
 version of XSPEC the code was compiled against)?
@@ -116,7 +116,7 @@ other models, apart from requiring `table` and `table_type` arguments:
 >>> y = x.tableModel(table=infile, table_type="add", energies=egrid, pars=pars)
 
 Note that it is very easy to make the table model code crash the
-system, such as by sending in not enough parameters or settnig a
+system, such as by sending in not enough parameters or setting a
 parameter outside its hard limits:
 
 >>> x.tableModel(infile, "add", pars=[1, 2], energies=egrid)
@@ -256,6 +256,7 @@ def info(model: str) -> XSPECModel:
         raise ValueError(f"Unrecognized XSPEC model '{model}'")
 
     return out
+
 
 # Do we need Optional here?
 def list_models(modeltype: Optional[ModelType] = None,


### PR DESCRIPTION
We can get the XSPEC version number by building a program which calls the necessary XSPEC "get me the version" routine. This is definitely OTT but I'm interested to see how useful it turns out to be.

At the moment we don't really take advantage of this information, and the build is hard-coded to prefer g++ rather than clang.